### PR TITLE
use redirectURI as clientID for CLI auth

### DIFF
--- a/pkg/indieauth/auth.go
+++ b/pkg/indieauth/auth.go
@@ -113,6 +113,8 @@ func GetEndpoints(me *url.URL) (Endpoints, error) {
 }
 
 // Authorize allows you to get the token from Indieauth through the command line
+// NOTE: clientID is ignored. instead, use the auto-generated redirectURI, which
+// IndieAuth clients should not attempt to fetch or parse.
 func Authorize(me *url.URL, endpoints Endpoints, clientID, scope string) (TokenResponse, error) {
 	var tokenResponse TokenResponse
 
@@ -130,7 +132,7 @@ func Authorize(me *url.URL, endpoints Endpoints, clientID, scope string) (TokenR
 	redirectURI := fmt.Sprintf("http://%s/", local)
 	state := util.RandStringBytes(16)
 
-	authorizationURL := CreateAuthorizationURL(*authURL, me.String(), clientID, redirectURI, state, scope)
+	authorizationURL := CreateAuthorizationURL(*authURL, me.String(), redirectURI, redirectURI, state, scope)
 
 	log.Printf("Browse to %s\n", authorizationURL)
 
@@ -175,7 +177,7 @@ func Authorize(me *url.URL, endpoints Endpoints, clientID, scope string) (TokenR
 	reqValues.Add("grant_type", "authorization_code")
 	reqValues.Add("code", code)
 	reqValues.Add("redirect_uri", redirectURI)
-	reqValues.Add("client_id", clientID)
+	reqValues.Add("client_id", redirectURI)
 	reqValues.Add("me", me.String())
 
 	req, err := http.NewRequest(http.MethodPost, endpoints.TokenEndpoint, strings.NewReader(reqValues.Encode()))


### PR DESCRIPTION
Currently, `ek connect` uses:

- a client ID of `https://p83.nl/microsub-client`
- a redirect URL of `http://127.0.0.1:XXXXX` (where `XXXXX` is the port it opened to listen on)

This means the redirect URL has a different host than the client ID. According to [4.2.2. Redirect URL](https://indieauth.spec.indieweb.org/#redirect-url) of the living IndieAuth spec:

> If a client wishes to use a redirect URL that has a different host than their `client_id`, or if the redirect URL uses a custom scheme (such as when the client is a native application), then the client will need to explicitly list those redirect URLs in the `redirect_uri` property of the client metadata so that authorization endpoints can be sure it is safe to redirect users there. Authorization endpoints verifying that a `redirect_uri` is allowed for use by a client MUST look for an exact match of the given `redirect_uri` in the request against the list of `redirect_uri`s after resolving any relative URLs.

The currently specified client ID of `https://p83.nl/microsub-client` serves a 404 with no content, so IndieAuth cannot continue.

This PR works around the issue by reusing the redirect URL as the client ID.

Making these the same means IndieAuth providers don't need to try and fetch a list of allowed `redirect_uri`s and, as a bonus [should not be fetching a client ID URL of `http://127.0.0.1` anyway](https://indieauth.spec.indieweb.org/#client-identifier).

Tested against (my personal IndieAuth server derived from) [Taproot/indieauth](https://github.com/Taproot/indieauth) with [aaronpk/Aperture](https://github.com/aaronpk/Aperture) as my Microsub server.